### PR TITLE
Make rplugin_Rgui global.

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2963,7 +2963,7 @@ if has("win32") || has("win64")
     if !exists("g:rplugin_rpathadded")
         if exists("g:vimrplugin_r_path") && isdirectory(g:vimrplugin_r_path)
             let $PATH = g:vimrplugin_r_path . ";" . $PATH
-            let b:rplugin_Rgui = g:vimrplugin_r_path . "\\Rgui.exe"
+            let g:rplugin_Rgui = g:vimrplugin_r_path . "\\Rgui.exe"
         else
             Py GetRPathPy()
             if s:rinstallpath == "Not found"
@@ -2977,14 +2977,14 @@ if has("win32") || has("win64")
                 endif
                 if g:vimrplugin_i386
                     let $PATH = s:rinstallpath . '\bin\i386;' . $PATH
-                    let b:rplugin_Rgui = s:rinstallpath . '\bin\i386\Rgui.exe'
+                    let g:rplugin_Rgui = s:rinstallpath . '\bin\i386\Rgui.exe'
                 else
                     let $PATH = s:rinstallpath . '\bin\x64;' . $PATH
-                    let b:rplugin_Rgui = s:rinstallpath . '\bin\x64\Rgui.exe'
+                    let g:rplugin_Rgui = s:rinstallpath . '\bin\x64\Rgui.exe'
                 endif
             else
                 let $PATH = s:rinstallpath . '\bin;' . $PATH
-                let b:rplugin_Rgui = s:rinstallpath . '\bin\Rgui.exe'
+                let g:rplugin_Rgui = s:rinstallpath . '\bin\Rgui.exe'
             endif
             unlet s:rinstallpath
         endif

--- a/r-plugin/windows.py
+++ b/r-plugin/windows.py
@@ -88,7 +88,7 @@ def GetRPathPy():
             vim.command("let s:rinstallpath =  'Not found'")
 
 def StartRPy():
-    rpath = vim.eval("b:rplugin_Rgui")
+    rpath = vim.eval("g:rplugin_Rgui")
     rargs = ['"' + rpath + '"']
     r_args = vim.eval("b:rplugin_r_args")
     if r_args != " ":


### PR DESCRIPTION
If rplugin_Rgui is local to the buffer, there is an error on Windows when multiple buffers are open in R (multiple buffers in the same session): when you try to start an R terminal from any buffer other than the first that was opened, an error is thrown ("vim.error: invalid expression) from line 91 of windows.py, as the rplugin_Rgui variable is not defined.

This fix works for me, but there may be a better way of fixing this. Not sure if other code relies on rplugin_Rgui being local to the buffer.
