### PR TITLE
set knitr::spin to <LocalLeader>ks for r-filetype

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -393,6 +393,7 @@ Command
   . Sweave, BibTeX and PDF (cur file) (Linux/Unix)     \sb
   --------------------------------------------------------
   . Knit (cur file)                                    \kn
+  . Spin (cur file)                                    \ks
   . Knit and PDF (cur file)                            \kp
   . Knit and Beamer PDF (cur file) (Only Rmd)          \ks
   . Knit and PDF (cur file, verbose) (Windows)         \kv

--- a/ftplugin/r.vim
+++ b/ftplugin/r.vim
@@ -83,6 +83,13 @@ function! ShowRout()
     endif
 endfunction
 
+" Sweave the current buffer content
+function! RSpin()
+    update
+    let b:needsnewomnilist = 1
+    call RSetWD()
+    call SendCmdToR('require(knitr); spin("' . expand("%:t") . '")')
+endfunction
 
 "==========================================================================
 " Key bindings and menu items
@@ -94,6 +101,10 @@ call RCreateEditMaps()
 call RCreateMaps("ni", '<Plug>RSendFile',     'aa', ':call SendFileToR("silent")')
 call RCreateMaps("ni", '<Plug>RESendFile',    'ae', ':call SendFileToR("echo")')
 call RCreateMaps("ni", '<Plug>RShowRout',     'ao', ':call ShowRout()')
+
+" Knitr::spin
+" -------------------------------------
+call RCreateMaps("ni", '<Plug>RSpinFile',     'ks', ':call RSpin()')
 
 call RCreateSendMaps()
 call RControlMaps()

--- a/ftplugin/rmd.vim
+++ b/ftplugin/rmd.vim
@@ -158,7 +158,7 @@ call RCreateMaps("nvi", '<Plug>RSetwd',        'rd', ':call RSetWD()')
 " Only .Rmd files use these functions:
 call RCreateMaps("nvi", '<Plug>RKnit',        'kn', ':call RKnit()')
 call RCreateMaps("nvi", '<Plug>RMakePDFK',    'kp', ':call RMakePDF("latex")')
-call RCreateMaps("nvi", '<Plug>RMakePDFK',    'ks', ':call RMakePDF("beamer")')
+call RCreateMaps("nvi", '<Plug>RMakePDFK',    'kl', ':call RMakePDF("beamer")')
 call RCreateMaps("nvi", '<Plug>RIndent',      'si', ':call RmdToggleIndentSty()')
 call RCreateMaps("ni",  '<Plug>RSendChunk',   'cc', ':call SendChunkToR("silent", "stay")')
 call RCreateMaps("ni",  '<Plug>RESendChunk',  'ce', ':call SendChunkToR("echo", "stay")')

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -40,6 +40,7 @@ syn match rOKeyword contained "@\(format\|importClassesFrom\|importFrom\|importM
 syn match rOKeyword contained "@\(method\|nord\|note\|references\|seealso\|setClass\|slot\|source\|title\|usage\)"
 syn match rOComment contains=@Spell,rOKeyword "#'.*"
 
+
 if &filetype == "rhelp"
   " string enclosed in double quotes
   syn region rString contains=rSpecial,@Spell start=/"/ skip=/\\\\\|\\"/ end=/"/


### PR DESCRIPTION
I added support for `knitr::spin` within R-files (<LocalLeader>ks). 
## What I didn't manage to do
- (markdown-) syntax-highlighting in `#'`-blocks (maybe thats not really needed)
- syntax-highlighting for `knitr`-options in `#+`-lines
