### PR TITLE
Option to disable insert-mode commands

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -895,6 +895,7 @@ IPv6 one (fe80::1).
 |vimrplugin_ca_ck|             Add ^A^K to the beginning of commands.
 |vimrplugin_openpdf|           Open PDF after processing rnoweb file.
 |vimrplugin_openpdf_quietly|   Open PDF quietly.
+|vimrplugin_insert_mode_cmds|  Allow R commands in insert mode.
 
 
 6.1. Terminal emulator (Linux/Unix only)~
@@ -1324,11 +1325,24 @@ will affect both Vim and R.
 
 On Linux/Unix, when vimrplugin_openpdf = 1, the application used to open the
 pdf may be quite verbose, printing many lines of useless diagnostic messages
-in the R Console. Put the following in you |vimrc| to inhibit these messages
+in the R Console. Put the following in your |vimrc| to inhibit these messages
 (and all useful error messages):
 >
    let vimrplugin_openpdf_quietly = 1
 <
+6.24. Allow R commands in insert mode~
+						 *Vimrplugin_insert_mode_cmds*
+Vim-R commands are designed to work in insert mode as well as normal mode.
+However, depending on your <LocalLeader>, this can make it very difficult to
+write R packages or Sweave files.  For example, if <LocalLeader> is set to the
+'\' character, typing '\dQuote' in a .Rd file tries to send the command!
+
+The option vimrplugin_insert_mode_cmds disables commands in insert mode.  To
+use it, add the following in your |vimrc|:
+>
+   let g:vimrplugin_insert_mode_cmds = 0       
+<
+The default value is 1, for consistency with earlier versions.
 
 ==============================================================================
 						       *r-plugin-key-bindings*

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2312,7 +2312,7 @@ function RCreateMaps(type, plug, combo, target)
             exec 'vnoremap <buffer><silent> <LocalLeader>' . a:combo . ' <Esc>' . tg
         endif
     endif
-    if a:type =~ "i"
+    if g:vimrplugin_insert_mode_cmds == 1 && a:type =~ "i"
         if hasmapto(a:plug, "i")
             exec 'inoremap <buffer><silent> ' . a:plug . ' <Esc>' . tg . il
         else
@@ -2830,6 +2830,7 @@ call RSetDefaultValue("g:vimrplugin_never_unmake_menu", 0)
 call RSetDefaultValue("g:vimrplugin_vimpager",       "'tab'")
 call RSetDefaultValue("g:vimrplugin_latexcmd", "'pdflatex'")
 call RSetDefaultValue("g:vimrplugin_objbr_place", "'script,right'")
+call RSetDefaultValue("g:vimrplugin_insert_mode_cmds",  1)
 
 " Look for invalid options
 let objbrplace = split(g:vimrplugin_objbr_place, ",")


### PR DESCRIPTION
Insert-mode commands can be extremely annoying when writing R documentation and/or Sweave files.  Example: when I'm in insert mode, I can't type `\dQuote`; the cursor jumps as soon as I type `\d`.  Solution: add the `g:vimrplugin_insert_mode_cmds` option, which defaults to 1 (compatibility with earlier versions) and can be set to 0 to disable insert mode commands.

I added

``` vim
:let g:vimrplugin_insert_mode_cmds = 0
```

to my `.vimrc`, and it appears to work great.  Setting it to 1 brings back the annoying jumpy behavior.
