### PR TITLE
Syntax highlighting for R code chunks in HTML file

### DIFF
--- a/ftplugin/rmd.vim
+++ b/ftplugin/rmd.vim
@@ -106,7 +106,7 @@ endfunction
 function! RMakeHTMLrmd(t)
     call RSetWD()
     update
-    let rcmd = 'require(knitr); knit2html("' . expand("%:t") . '", options = "")'
+    let rcmd = 'require(knitr); knit2html("' . expand("%:t") . '")'
     if a:t == "odt"
         if g:rplugin_has_soffice == 0
             if has("win32") || has("win64")


### PR DESCRIPTION
## Problem

In the knitted HTML output the R code chunks are not highlighted.
## Issue

Calling knit2html() with the options as an empty string changes
the default options. That is

```
knit2html("file.Rmd", options="")   # No syntax highlight
knit2html("file.Rmd")               # Yes to Syntax Highlight
```
## Solution

Remove the options argument.
## Effect

Highlighted R code in knitted HTML file. As desired.
