### PR TITLE
rst2pdf path fix

### DIFF
--- a/ftplugin/rrst.vim
+++ b/ftplugin/rrst.vim
@@ -138,7 +138,9 @@ function! RMakePDFrrst()
     update
     call RSetWD()
     if g:rplugin_has_rst2pdf == 0
-        if executable("rst2pdf")
+        if exists("g:vimrplugin_rst2pdfpath") && executable(g:vimrplugin_rst2pdfpath)
+            let g:rplugin_has_rst2pdf = 1
+        elseif executable("rst2pdf")
             let g:rplugin_has_rst2pdf = 1
         else
             call RWarningMsg("Is 'rst2pdf' application installed? Cannot convert into PDF: 'rst2pdf' executable not found.")
@@ -154,7 +156,7 @@ function! RMakePDFrrst()
         let pdfcmd = pdfcmd . ", " . g:vimrplugin_knitargs
     endif
     if exists("g:vimrplugin_rst2pdfpath")
-        pdfcmd = pdfcmd . ", rst2pdfpath='" . g:vimrplugin_rst2pdf_path . "'"
+        let pdfcmd = pdfcmd . ", rst2pdfpath='" . g:vimrplugin_rst2pdfpath . "'"
     endif
     if exists("g:vimrplugin_rst2pdfargs")
         let pdfcmd = pdfcmd . ", " . g:vimrplugin_rst2pdfargs


### PR DESCRIPTION
If specified, check if g:vimrplugin_rst2pdfpath is executable before checking if rst2pdf is in the path.

Also fix bug in adding g:vimrplugin_rst2pdf_path to the pdfcmd.
