### PR TITLE
Pave the way for YCM compatibility

### DIFF
--- a/autoload/rcomplete.vim
+++ b/autoload/rcomplete.vim
@@ -51,5 +51,5 @@ fun! rcomplete#CompleteR(findstart, base)
   endif
 endfun
 
-set completefunc=CompleteR
+set omnifunc=CompleteR
 


### PR DESCRIPTION
Summary: use `omnifunc` (which is for filetype-specific completions) rather than `completefunc` (which is for completions in all filetypes).

Reference:
https://github.com/Valloric/YouCompleteMe/issues/471
