### PR TITLE
allow indented code chunks in rmd

### DIFF
--- a/ftplugin/rmd.vim
+++ b/ftplugin/rmd.vim
@@ -54,9 +54,9 @@ runtime r-plugin/common_buffer.vim
 
 function! RmdIsInRCode()
     let curline = line(".")
-    let chunkline = search("^```[ ]*{r", "bncW")
+    let chunkline = search("^[ ]*\t*```[ ]*{r", "bncW")
     call cursor(chunkline)
-    let docline = search("^```$", "ncW")
+    let docline = search("^[ ]*\t*```$", "ncW")
     call cursor(curline)
     if 0 < chunkline && chunkline < curline && curline < docline
         return 1
@@ -71,12 +71,12 @@ function! RmdPreviousChunk() range
     for var in range(1, chunk)
         let curline = line(".")
         if RmdIsInRCode()
-            let i = search("^```[ ]*{r", "bnW")
+            let i = search("^[ ]*\t*```[ ]*{r", "bnW")
             if i != 0
                 call cursor(i-1, 1)
             endif
         endif
-        let i = search("^```[ ]*{r", "bnW")
+        let i = search("^[ ]*\t*```[ ]*{r", "bnW")
         if i == 0
             call cursor(curline, 1)
             call RWarningMsg("There is no previous R code chunk to go.")
@@ -92,7 +92,7 @@ function! RmdNextChunk() range
     let rg = range(a:firstline, a:lastline)
     let chunk = len(rg)
     for var in range(1, chunk)
-        let i = search("^```[ ]*{r", "nW")
+        let i = search("^[ ]*\t*```[ ]*{r", "nW")
         if i == 0
             call RWarningMsg("There is no next R code chunk to go.")
             return
@@ -170,8 +170,8 @@ function! SendRmdChunkToR(e, m)
         call RWarningMsg("Not inside an R code chunk.")
         return
     endif
-    let chunkline = search("^```[ ]*{r", "bncW") + 1
-    let docline = search("^```", "ncW") - 1
+    let chunkline = search("^[ ]*\t*```[ ]*{r", "bncW") + 1
+    let docline = search("^[ ]*\t*```", "ncW") - 1
     let lines = getline(chunkline, docline)
     let b:needsnewomnilist = 1
     let ok = RSourceLines(lines, a:e)

--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -36,13 +36,13 @@ setlocal iskeyword=@,48-57,_,.
 
 if exists("g:rmd_syn_hl_chunk")
     " highlight R code inside chunk header
-    syntax match rmdChunkDelim "^```{r" contained
+    syntax match rmdChunkDelim "^[ ]*\t*```{r" contained
     syntax match rmdChunkDelim "}$" contained
 else
-    syntax match rmdChunkDelim "^```{r.*}$" contained
+    syntax match rmdChunkDelim "^[ ]*\t*```{r.*}$" contained
 endif
-syntax match rmdChunkDelim "^```$" contained
-syntax region rmdChunk start="^``` *{r.*}$" end="^```$" contains=@R,rmdChunkDelim keepend transparent fold
+syntax match rmdChunkDelim "^[ ]*\t*```$" contained
+syntax region rmdChunk start="^[ ]*\t*``` *{r.*}$" end="^```$" contains=@R,rmdChunkDelim keepend transparent fold
 
 " also match and syntax highlight in-line R code
 syntax match rmdEndInline "`" contained


### PR DESCRIPTION
It can be convenient to indent code chunks in Rmd files.  For example, when in the middle of an ordered list.  This should allow markup and code execution for code chunks in Rmd files when indented (or not) with either spaces or tabs.
