### PR TITLE
fix rmd r syntax end expression

### DIFF
--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -42,7 +42,7 @@ else
     syntax match rmdChunkDelim "^[ \t]*```{r.*}$" contained
 endif
 syntax match rmdChunkDelim "^[ \t]*```$" contained
-syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^```$" contains=@R,rmdChunkDelim keepend transparent fold
+syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^[ \t]*```$" contains=@R,rmdChunkDelim keepend transparent fold
 
 " also match and syntax highlight in-line R code
 syntax match rmdEndInline "`" contained


### PR DESCRIPTION
Syntax region close expression for rmd chunk did not allow for extra white space.
