### PR TITLE
improve rmd syntax matching

### DIFF
--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -42,12 +42,15 @@ else
     syntax match rmdChunkDelim "^[ \t]*```{r.*}$" contained
 endif
 syntax match rmdChunkDelim "^[ \t]*```$" contained
-syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^[ \t]*```$" contains=@R,rmdChunkDelim keepend transparent fold
+syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^[ \t]*```$" contains=@R,rmdChunkDelim keepend fold
 
 " also match and syntax highlight in-line R code
 syntax match rmdEndInline "`" contained
 syntax match rmdBeginInline "`r " contained
-syntax region rmdrInline start="`r "  end="`" contains=@R,rmdBeginInline,rmdEndInline keepend transparent
+syntax region rmdrInline start="`r "  end="`" contains=@R,rmdBeginInline,rmdEndInline keepend
+
+" match slidify special marker
+syntax match rmdSlidifySpecial "\*\*\*"
 
 
 if rmdIsPandoc == 0
@@ -65,6 +68,7 @@ if rmdIsPandoc == 0
     syntax match rmdLaTeXRegDelim "\$\$" contained
     syntax match rmdLaTeXRegDelim "\$\$latex$" contained
     syntax region rmdLaTeXRegion start="^\$\$" skip="\\\$" end="^\$\$" contains=@LaTeX,rmdLaTeXSt,rmdLaTeXRegDelim keepend 
+    syntax region rmdLaTeXRegion2 start="^\\\[" end="\\\]" contains=@LaTeX,rmdLaTeXSt,rmdLaTeXRegDelim keepend
     hi def link rmdLaTeXSt Statement
     hi def link rmdLaTeXInlDelim Special
     hi def link rmdLaTeXRegDelim Special
@@ -74,5 +78,6 @@ hi def link rmdChunkDelim Special
 hi def link rmdBeginInline Special
 hi def link rmdEndInline Special
 hi def link rmdBlockQuote Comment
+hi def link rmdSlidifySpecial Special
 
 let b:current_syntax = "rmd"


### PR DESCRIPTION
Here are some edits I have been using for rmd syntax.
I removed transparent for the r regions to prevent highlighting of misspelled  words in r code.
I added an additional latex region defined by [ ]
I also added a match of **\* which is used in slidify to denote special slide properties.

Thanks for taking a look.
