### PR TITLE
Add .gitignore and ignore /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
The helptags command produces the tags file, which should be ignored by git.

When using Vim-R-plugin as a submodule (via the pathogen plugin), and after running the helptags command (:Helptags via pathogen), git reports that the Vim-R-plugin submodule has uncommitted changes (the newly created tags file). This tags file should be ignored by git.

Compare with vim-fugitive, https://github.com/tpope/vim-fugitive/blob/master/.gitignore
