### PR TITLE
add highlighting support for BUG, FIXME, NOTE and TODO keywords in comments

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -30,7 +30,8 @@ endif
 syn case match
 
 " Comment
-syn match rComment contains=@Spell "#.*"
+syn match rCommentTodo contained "\(BUG\|FIXME\|NOTE\|TODO\):"
+syn match rComment contains=@Spell,rCommentTodo "#.*"
 
 " Roxygen
 syn match rOKeyword contained "@\(param\|return\|name\|rdname\|examples\|include\|docType\)"
@@ -187,6 +188,7 @@ hi def link rArrow       Statement
 hi def link rBoolean     Boolean
 hi def link rBraceError  Error
 hi def link rComment     Comment
+hi def link rCommentTodo Todo
 hi def link rOComment    Comment
 hi def link rComplex     Number
 hi def link rConditional Conditional


### PR DESCRIPTION
This pull request adds some special highlighting for the following keywords:
`BUG:`, `FIXME:`, `NOTE:` and `TODO:`

before commit:
![todo1](https://f.cloud.github.com/assets/1828443/1328968/03856468-350e-11e3-8b17-5813c0e67127.png)

after commit:
![todo](https://f.cloud.github.com/assets/1828443/1328969/0751b4d4-350e-11e3-9d00-9f8c4f456da7.png)
