### PR TITLE
option to set maximum help text width

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -928,6 +928,7 @@ is running:
 |vimrplugin_vimpager|          Use Vim to see R documentation
 |vimrplugin_editor_w|          Minimum width of R script buffer
 |vimrplugin_help_w|            Desired width of R documentation buffer
+|vimrplugin_htw|               Maximum text width of R documentation
 |vimrplugin_i386|              Use 32 bit version of R
 |vimrplugin_r_path|            Directory where R is
 |vimrplugin_r_args|            Arguments to pass to R
@@ -1065,6 +1066,7 @@ work on the Object Browser (you will see the message "Cmd not available").
 							 *vimrplugin_vimpager*
 							 *vimrplugin_editor_w*
 							   *vimrplugin_help_w*
+							      *vimrplugin_htw*
 6.5.1. Quick setup~
 
 If you do not want to see R documentation in a Vim's buffer, put in your
@@ -1106,6 +1108,10 @@ values to some variables in your |vimrc|, as in the example:
 >
    let vimrplugin_editor_w = 80
    let vimrplugin_editor_h = 60
+<
+To set the maximum text width of the documentation, use vimrplugin_htw as in
+>
+   let vimrplugin_htw = 80
 <
 
 6.6. Use 32 bit version of R (Windows and Mac OS X only)~

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2029,6 +2029,9 @@ function SetRTextWidth()
             exe "language " . curlang
         endif
     endif
+    if exists('g:vimrplugin_htw') && g:vimrplugin_htw < g:rplugin_htw
+        let g:rplugin_htw = g:vimrplugin_htw
+    endif
 endfunction
 
 function RGetClassFor(rkeyword)


### PR DESCRIPTION
I think there is an issue in the way the text width is calculated for rhelp calls.  For example:

:echo g:vimrplugin_help_w
90
:echo g:rplugin_htw
98

I think the second number should be smaller than the first... I didn't want to adjust your algorithm in case you had a motivation for this, but regardless, I would like to be able set the maximum help text width independently of the buffer width so this pull request introduces a new variable to set the maximum text width: vimrplugin_htw
