### PR TITLE
allows opening R in an external terminal when tcsh is the default shell

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -643,7 +643,14 @@ function StartR_ExternalTerm(rcmd)
     endif
     call extend(cnflines, ['set-environment VIMINSTANCEID "' . $VIMINSTANCEID . '"'])
     call writefile(cnflines, s:tmxcnf)
-    let rcmd = "VIMINSTANCEID=" . $VIMINSTANCEID . " " . a:rcmd
+	
+	let is_bash = system('echo $BASH')
+	if v:shell_error || len(is_bash) == 0 || empty(matchstr(tolower(is_bash),'undefined variable')) == 0
+		let rcmd = a:rcmd
+	else
+		let rcmd = "VIMINSTANCEID=" . $VIMINSTANCEID . " " . a:rcmd
+	endif
+
     call system('export VIMRPLUGIN_TMPDIR=' . $VIMRPLUGIN_TMPDIR)
     call system('export VIMRPLUGIN_HOME=' . g:rplugin_home)
     call system('export VIMINSTANCEID=' . $VIMINSTANCEID)


### PR DESCRIPTION
In tcsh environment variables cannot be set on the command line, and therefore the external terminal fails. 

I'm not aware of a good way to identify the currently running shell so I'm assuming bash as the default
- If indeed the current shell is bash then $BASH should be defined (and the previous behavior is maintained).
- If it is not I fall back to a normal mode where only the desired command is specified. 

In my environment (tcsh is the organization default) this fix works.

Best,
Nir
