### PR TITLE
Fix issue relating to R Markdown single-line LaTeX $$display equations$$

### DIFF
--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -67,7 +67,7 @@ if rmdIsPandoc == 0
     " Region
     syntax match rmdLaTeXRegDelim "\$\$" contained
     syntax match rmdLaTeXRegDelim "\$\$latex$" contained
-    syntax region rmdLaTeXRegion start="^\$\$" skip="\\\$" end="^\$\$" contains=@LaTeX,rmdLaTeXSt,rmdLaTeXRegDelim keepend 
+    syntax region rmdLaTeXRegion start="^\$\$" skip="\\\$" end="\$\$$" contains=@LaTeX,rmdLaTeXSt,rmdLaTeXRegDelim keepend
     syntax region rmdLaTeXRegion2 start="^\\\[" end="\\\]" contains=@LaTeX,rmdLaTeXSt,rmdLaTeXRegDelim keepend
     hi def link rmdLaTeXSt Statement
     hi def link rmdLaTeXInlDelim Special


### PR DESCRIPTION
Fix issue relating to R Markdown single-line LaTeX $$display equations$$

Currently, single-line LaTeX equations like:

$$ x=0 $$

break all of the syntax highlighting below the line in R Markdown files.

This PR should fix the issue by allow both single-line and multiline equations as long as the line with the equation ends with a "$$".
## Test

Some _Markdown_ text **here**.

``` r
x <- 'test'
print('before LaTeX block.')
```

$$latex$$

no more highlighting from here down...

``` r
x <- 'including code blocks.'
print('after LaTeX block.')
```
