### PR TITLE
add support for slidify

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -417,6 +417,7 @@ Command
   . Knit and HTML (cur file, verbose) (only .Rmd)      \kh
   . Knit and PDF (cur file, verbose) (Windows)         \kv
   . Spin (cur file) (only .R)                          \ks
+  . Slidify (cur file) (only .Rmd)                     \sl
   --------------------------------------------------------
   . Open PDF (cur file)                                \op
   --------------------------------------------------------
@@ -1623,6 +1624,7 @@ RD, "cursor down"; RED, both "echo" and "down"):
    RMakePDFKb (.Rmd, beamer)
    ROpenPDF
    RSpinFile
+   RMakeSlides (Slidify)
 
    Object browser~
    RUpdateObjBrowser

--- a/ftplugin/rmd.vim
+++ b/ftplugin/rmd.vim
@@ -128,6 +128,17 @@ function! RMakeHTMLrmd(t)
     call g:SendCmdToR(rcmd)
 endfunction
 
+function! RMakeSlidesrmd()
+    call RSetWD()
+    update
+    let rcmd = 'require(slidify); slidify("' . expand("%:t") . '")'
+    if g:vimrplugin_openhtml
+        let rcmd = rcmd . '; browseURL("' . expand("%:r:t") . '.html")'
+    endif
+    call g:SendCmdToR(rcmd)
+endfunction
+
+
 function! RMakePDFrmd(t)
     if g:rplugin_vimcomport == 0
         exe "Py DiscoverVimComPort()"
@@ -200,6 +211,7 @@ call RCreateMaps("nvi", '<Plug>RKnit',        'kn', ':call RKnit()')
 call RCreateMaps("nvi", '<Plug>RMakePDFK',    'kp', ':call RMakePDFrmd("latex")')
 call RCreateMaps("nvi", '<Plug>RMakePDFKb',   'kl', ':call RMakePDFrmd("beamer")')
 call RCreateMaps("nvi", '<Plug>RMakeHTML',    'kh', ':call RMakeHTMLrmd("html")')
+call RCreateMaps("nvi", '<Plug>RMakeSlides',  'sl', ':call RMakeSlidesrmd()')
 call RCreateMaps("nvi", '<Plug>RMakeODT',     'ko', ':call RMakeHTMLrmd("odt")')
 call RCreateMaps("ni",  '<Plug>RSendChunk',   'cc', ':call b:SendChunkToR("silent", "stay")')
 call RCreateMaps("ni",  '<Plug>RESendChunk',  'ce', ':call b:SendChunkToR("echo", "stay")')

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2637,6 +2637,7 @@ function MakeRMenu()
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ Beamer\ PDF\ (cur\ file)', '<Plug>RMakePDFKb', 'kl', ':call RMakePDFrmd("beamer")')
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ HTML\ (cur\ file)', '<Plug>RMakeHTML', 'kh', ':call RMakeHTMLrmd("html")')
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ ODT\ (cur\ file)', '<Plug>RMakeODT', 'ko', ':call RMakeHTMLrmd("odt")')
+            call RCreateMenuItem("nvi", 'Command.Slidify\ (cur\ file)', '<Plug>RMakeSlides', 'sl', ':call RMakeSlidesrmd()')
         endif
         if &filetype == "rrst" || g:vimrplugin_never_unmake_menu
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ PDF\ (cur\ file)', '<Plug>RMakePDFK', 'kp', ':call RMakePDFrrst()')


### PR DESCRIPTION
This gives basic support for the [slidfy](https://github.com/ramnathv/slidify) package.  Slidify will markup Rmd files to html in any of many html slideshow frameworks.  I set the default keybinding to sl.
