### PR TITLE
Improved ftplugin settings for comments

### DIFF
--- a/ftplugin/r.vim
+++ b/ftplugin/r.vim
@@ -17,7 +17,7 @@ set cpo&vim
 setlocal iskeyword=@,48-57,_,.
 setlocal formatoptions-=t
 setlocal commentstring=#\ %s
-setlocal comments=:#,:##,:###,:#'
+setlocal comments=:#',:###,:##,:#
 
 if has("gui_win32") && !exists("b:browsefilter")
   let b:browsefilter = "R Source Files (*.R)\t*.R\n" .


### PR DESCRIPTION
This pull request addresses two issues with the `comments` and `commentstring` settings.
-   The `commentstring` should have a space separating comment character and comment text. In my experience, style guides universally recommend having a space there (see for example Google R style guide):
  
  ```
  #bad style
  # good style
  ```
  
  The `commentstring` setting is used for _producing_ comments, thus it currently produces comments in `#bad style`.
-   The `comments` settings should not have the `b` flag, since the whitespace following `#` is not required syntactically in R.
  
  Consequences of the current setting are, for example, that it is not possible to reformat
  
  ```
  #paragraphs
  #in this
  #style
  ```
  
  with `gq` because they are not recognised by Vim as comments due to the `b` flag.

For reference I'd like to point to the tpope-maintained Ruby ftplugin which has

```
setlocal comments=:#
setlocal commentstring=#\ %s
```
