### PR TITLE
allow for custom executable

### DIFF
--- a/r-plugin/global_r_plugin.vim
+++ b/r-plugin/global_r_plugin.vim
@@ -38,7 +38,16 @@ endfunction
 
 function SetExeCmd()
     runtime r-plugin/common_buffer.vim
-    if &filetype == "julia"
+    if exists("g:vimrplugin_exe") && exists("g:vimrplugin_quit")
+        let b:rplugin_R = g:vimrplugin_exe
+        if exists("g:vimrplugin_args")
+            let b:rplugin_r_args = g:vimrplugin_args
+        else
+            let b:rplugin_r_args = " "
+        endif
+        let b:quit_command = g:vimrplugin_quit
+        let b:SourceLines = function("SourceNotDefined")
+    elseif &filetype == "julia"
         let b:rplugin_R = "julia"
         let b:rplugin_r_args = " "
         let b:quit_command = "quit()"


### PR DESCRIPTION
Here's an idea for allowing custom executable (and quit function) for the global plugin.  This way you don't need to accommodate every possible language with an interactive prompt and also so the user can specify exactly what they want.  For example, I have in ftplugin/octave.vim:

```
let vimrplugin_exe = "octave"
let vimrplugin_quit = "quit"
source Vim-R-plugin-directory/r-plugin/global_r_plugin.vim
```
