### PR TITLE
add function to send current line to R and write its output into the line below

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -1234,6 +1234,26 @@ function RInsert(cmd)
     endif
 endfunction
 
+function SendLineToRAndInsertOutput ()
+  let line = getline(".")
+  call RInsert("print(" . line . ")")
+  if g:rplugin_lastrpl == "R is busy." || g:rplugin_lastrpl == "UNKNOWN" || g:rplugin_lastrpl =~ "^Error" || g:rplugin_lastrpl == "INVALID" || g:rplugin_lastrpl == "ERROR" || g:rplugin_lastrpl == "EMPTY" || g:rplugin_lastrpl == "No reply"
+    return
+  else
+    " comment the output
+    let lastLine = line("$")
+    let line = getline(".")
+    let i = line(".")
+    call cursor(i, 1)
+    while strlen(line) > 0 && i <= lastLine
+      call RSimpleCommentLine("normal", "c")
+      let i = line(".") + 1
+      call cursor(i, 1)
+      let line = substitute(getline("."), '^\s*', "", "")
+    endwhile
+  endif
+endfunction
+
 " Function to send commands
 " return 0 on failure and 1 on success
 function SendCmdToR_fake(cmd)
@@ -2598,6 +2618,7 @@ function MakeRMenu()
     menu R.Send.-Sep6- <nul>
     call RCreateMenuItem("ni0", 'Send.Line', '<Plug>RSendLine', 'l', ':call SendLineToR("stay")')
     call RCreateMenuItem("ni0", 'Send.Line\ (and\ down)', '<Plug>RDSendLine', 'd', ':call SendLineToR("down")')
+    call RCreateMenuItem("ni0", 'Send.Line\ (and\ insert\ output)', '<Plug>RDSendLineAndInsertOutput', 'lo', ':call SendLineToRAndInsertOutput()')
     call RCreateMenuItem("i", 'Send.Line\ (and\ new\ one)', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
     call RCreateMenuItem("n", 'Send.Left\ part\ of\ line\ (cur)', '<Plug>RNLeftPart', 'r<Left>', ':call RSendPartOfLine("left", 0)')
     call RCreateMenuItem("n", 'Send.Right\ part\ of\ line\ (cur)', '<Plug>RNRightPart', 'r<Right>', ':call RSendPartOfLine("right", 0)')
@@ -2925,6 +2946,7 @@ function RCreateSendMaps()
     "-------------------------------------
     call RCreateMaps("ni", '<Plug>RSendLine', 'l', ':call SendLineToR("stay")')
     call RCreateMaps('ni0', '<Plug>RDSendLine', 'd', ':call SendLineToR("down")')
+    call RCreateMaps('ni0', '<Plug>RDSendLineAndInsertOutput', 'lo', ':call SendLineToRAndInsertOutput()')
     call RCreateMaps('i', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
     nmap <LocalLeader>r<Left> :call RSendPartOfLine("left", 0)<CR>
     nmap <LocalLeader>r<Right> :call RSendPartOfLine("right", 0)<CR>


### PR DESCRIPTION
Hello Jakson,

to insert the output of an R command the vim-r-plugin has already the `RInsert` command. But often I find it cumbersome to use (because you have to write `:Rinsert print(foo)` into vims commandline).
This pull request introduces a new function `SendLineToRAndInsertOutput` that sends the current line to R, evaluates it and writes its output into the line below and comment it out:

```
foo <- 1:10
```

becomes (after hitting _leader + lo_):

```
 foo <- 1:10
 #  [1]  1  2  3  4  5  6  7  8  9 10
```

Best wishes,

Sebastian
