### PR TITLE
fix roxygen noRd keyword

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -38,7 +38,7 @@ syn match rOKeyword contained "@\(param\|return\|name\|rdname\|examples\|include
 syn match rOKeyword contained "@\(S3method\|TODO\|aliases\|alias\|assignee\|author\|callGraphDepth\|callGraph\)"
 syn match rOKeyword contained "@\(callGraphPrimitives\|concept\|exportClass\|exportMethod\|exportPattern\|export\|formals\)"
 syn match rOKeyword contained "@\(format\|importClassesFrom\|importFrom\|importMethodsFrom\|import\|keywords\)"
-syn match rOKeyword contained "@\(method\|nord\|note\|references\|seealso\|setClass\|slot\|source\|title\|usage\)"
+syn match rOKeyword contained "@\(method\|noRd\|note\|references\|seealso\|setClass\|slot\|source\|title\|usage\)"
 syn match rOComment contains=@Spell,rOKeyword "#'.*"
 
 


### PR DESCRIPTION
Dear Jakson,

this PR fix the definition of the _roxygen2_ keyword `@noRd`. 
See also https://github.com/yihui/roxygen2/blob/master/R/roclet-rd.R#L39

Best wishes,

Sebastian
