### PR TITLE
Option to use Vim wd as R wd

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -1117,6 +1117,7 @@ is running:
 |vimrplugin_restart|           Restart R if it is already running
 |vimrplugin_show_args|         Show extra information during omnicompletion
 |vimrplugin_vimcom_wait|       Time to wait for vimcom.plus loading
+|vimrplugin_vim_wd|            Start R in working directory of Vim
 
 
 6.1. Terminal emulator (Linux/Unix only)~
@@ -1674,6 +1675,14 @@ If you do not want to install the vimcom.plus package, then put in your
    let vimrplugin_vimcom_wait = -1
 <
 
+6.31 Start R in working directory of Vim
+						      *vimrplugin_vim_wd*
+The Vim-R-plugin starts R such R's working directory contains the file in the
+current vim buffer.  If you want R's working directory to be the same as Vim's
+working directory, put in your vimrc:
+>
+    let vimrplugin_vim_wd = 1
+<
 
 ==============================================================================
 						       *r-plugin-key-bindings*

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -718,7 +718,9 @@ function StartR_Windows()
         endif
     endif
     Py StartRPy()
-    lcd -
+    if !exists("g:vimrplugin_vim_wd") || g:vimrplugin_vim_wd == 0
+        lcd -
+    endif
     let g:SendCmdToR = function('SendCmdToR_Windows')
     call WaitVimComStart()
 endfunction
@@ -741,7 +743,9 @@ function StartR_OSX()
     if v:shell_error
         call RWarningMsg(rlog)
     endif
-    lcd -
+    if !exists("g:vimrplugin_vim_wd") || g:vimrplugin_vim_wd == 0
+        lcd -
+    endif
     let g:SendCmdToR = function('SendCmdToR_OSX')
     if WaitVimComStart()
         Py SendToVimCom("\001Update OB [StartR]")
@@ -773,7 +777,9 @@ function StartR(whatr)
     endif
 
     " Change to buffer's directory before starting R
-    lcd %:p:h
+    if !exists("g:vimrplugin_vim_wd") || g:vimrplugin_vim_wd == 0
+        lcd %:p:h
+    endif
 
     if a:whatr =~ "vanilla"
         let b:rplugin_r_args = "--vanilla"
@@ -797,7 +803,9 @@ function StartR(whatr)
 
     if g:vimrplugin_only_in_tmux && $TMUX_PANE == ""
         call RWarningMsg("Not inside Tmux.")
-        lcd -
+        if !exists("g:vimrplugin_vim_wd") || g:vimrplugin_vim_wd == 0
+            lcd -
+        endif
         return
     endif
 
@@ -862,7 +870,9 @@ function StartR(whatr)
     endif
 
     " Go back to original directory:
-    lcd -
+    if !exists("g:vimrplugin_vim_wd") || g:vimrplugin_vim_wd == 0
+        lcd -
+    endif
     echon
 endfunction
 


### PR DESCRIPTION
I've added an option to start R with a working directory that is vim's working directory rather than the directory of the file in the current buffer.  I think this would be a nice option to have especially since there is a command (\rd) to set the directory to that of the file you are editing.

I think this is especially convenient if you are working on a package and want R and Vim to be in the package/ directory rather than the package/R/ directory.

Thanks for taking a look.
