### PR TITLE
set view argument for vim.interlace.rmd

### DIFF
--- a/ftplugin/rmd_rplugin.vim
+++ b/ftplugin/rmd_rplugin.vim
@@ -132,6 +132,17 @@ function! RMakePDFrmd(t)
     if exists("g:vimrplugin_pandoc_args")
         let pdfcmd = pdfcmd . ", pandoc_args = '" . g:vimrplugin_pandoc_args . "'"
     endif
+    if g:vimrplugin_openpdf == 0
+        let pdfcmd = pdfcmd . ", view = FALSE"
+    else
+        if g:vimrplugin_openpdf == 1
+            if b:pdf_opened == 0
+                let b:pdf_opened = 1
+            else
+                let pdfcmd = pdfcmd . ", view = FALSE"
+            endif
+        endif
+    endif
     let pdfcmd = pdfcmd . ")"
     call g:SendCmdToR(pdfcmd)
 endfunction  


### PR DESCRIPTION
When building a pdf from rmd, the pdf is currently opened even if g:vimrplugin_openpdf is set to 0.  I just copied the relevant code from rnw_rplugin.vim to rmd_rplugin.vim so that g:vimrplugin_openpdf is now respected.  I don't use rrst but I think that the same issue might be present there.
