### PR TITLE
Check if line is end of code chunk in rmd

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -1806,6 +1806,9 @@ function SendParagraphToR(e, m)
         if &filetype == "rnoweb" && line =~ "^@$"
             let j -= 1
             break
+        elseif &filetype == "rmd" && line =~ "^[ \t]*```$"
+            let j -= 1
+            break
         endif
         if line =~ '^\s*$'
             break


### PR DESCRIPTION
The last line of a paragraph (to send to R) in rmd files should be defined by a blank line or the end of the code chunk.  There is already a test for rnoweb files.  This adds the equivalent test for rmd files.
