### PR TITLE
Don't set help files to nomodifiable.

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2455,7 +2455,8 @@ function ShowRDoc(rkeyword, package, getclass)
     normal! gg
     let @@ = save_unnamed_reg
     setlocal nomodified
-    setlocal nomodifiable
+    setlocal modifiable
+    setlocal readonly
     redraw
 endfunction
 


### PR DESCRIPTION
It's really neat to have R help files open up right in a vim buffer if for no other reason than the ability to very easily send the examples in the help files to the R console like any other R file.  However, since the help files are set to nomodifiable, you can't change the examples if you want to experiment unless you take some extra steps and copy into a modifiable buffer.  This PR sets the help files to readonly instead of nomodifiable.
