### PR TITLE
Checking that b:undo_ftplugin exists before appending to it

### DIFF
--- a/ftplugin/r_rplugin.vim
+++ b/ftplugin/r_rplugin.vim
@@ -97,5 +97,8 @@ endif
 
 call RSourceOtherScripts()
 
-
-let b:undo_ftplugin .= " | unlet! b:IsInRCode b:SourceLines"
+if exists("b:undo_ftplugin")
+    let b:undo_ftplugin .= " | unlet! b:IsInRCode b:SourceLines"
+else
+    let b:undo_ftplugin = "unlet! b:IsInRCode b:SourceLines"   
+endif


### PR DESCRIPTION
This plugin expects b:undo_ftplugin to exists which is not always the case. I made a very simple fix and it's very well possible that it can be written more succintly and idiomatically - but it worked for me :)
