### PR TITLE
Switch to rmarkdown for rmd files

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -442,7 +442,6 @@ Command
   . Knit and HTML (cur file, verbose) (only .Rmd)      \kh
   . Knit and PDF (cur file, verbose) (Windows)         \kv
   . Spin (cur file) (only .R)                          \ks
-  . Slidify (cur file) (only .Rmd)                     \sl
   --------------------------------------------------------
   . Open PDF (cur file)                                \op
   --------------------------------------------------------
@@ -1848,7 +1847,6 @@ RD, "cursor down"; RED, both "echo" and "down"):
    RMakeAll   (rmarkdown all in yaml)
    ROpenPDF
    RSpinFile
-   RMakeSlides (Slidify)
 
    Object browser~
    RUpdateObjBrowser

--- a/ftplugin/rmd_rplugin.vim
+++ b/ftplugin/rmd_rplugin.vim
@@ -106,16 +106,6 @@ function! RMakeRmd(t)
     call g:SendCmdToR(rcmd)
 endfunction
 
-function! RMakeSlidesrmd()
-    call RSetWD()
-    update
-    let rcmd = 'require(slidify); slidify("' . expand("%:t") . '")'
-    if g:vimrplugin_openhtml
-        let rcmd = rcmd . '; browseURL("' . expand("%:r:t") . '.html")'
-    endif
-    call g:SendCmdToR(rcmd)
-endfunction
-
 " Send Rmd chunk to R
 function! SendRmdChunkToR(e, m)
     if RmdIsInRCode(0) == 0
@@ -156,7 +146,6 @@ call RCreateMaps("nvi", '<Plug>RMakeAll',     'ka', ':call RMakeRmd("all")')
 call RCreateMaps("nvi", '<Plug>RMakePDFK',    'kp', ':call RMakeRmd("pdf")')
 call RCreateMaps("nvi", '<Plug>RMakePDFKb',   'kl', ':call RMakeRmd("beamer")')
 call RCreateMaps("nvi", '<Plug>RMakeHTML',    'kh', ':call RMakeRmd("html")')
-call RCreateMaps("nvi", '<Plug>RMakeSlides',  'sl', ':call RMakeSlidesrmd()')
 call RCreateMaps("nvi", '<Plug>RMakeODT',     'ko', ':call RMakeRmd("odt")')
 call RCreateMaps("ni",  '<Plug>RSendChunk',   'cc', ':call b:SendChunkToR("silent", "stay")')
 call RCreateMaps("ni",  '<Plug>RESendChunk',  'ce', ':call b:SendChunkToR("echo", "stay")')

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2892,7 +2892,6 @@ function MakeRMenu()
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ Beamer\ PDF\ (cur\ file)', '<Plug>RMakePDFKb', 'kl', ':call RMakeRmd("beamer")')
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ HTML\ (cur\ file)', '<Plug>RMakeHTML', 'kh', ':call RMakeRmd("html")')
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ ODT\ (cur\ file)', '<Plug>RMakeODT', 'ko', ':call RMakeRmd("odt")')
-            call RCreateMenuItem("nvi", 'Command.Slidify\ (cur\ file)', '<Plug>RMakeSlides', 'sl', ':call RMakeSlidesrmd()')
         endif
         if &filetype == "rrst" || g:vimrplugin_never_unmake_menu
             call RCreateMenuItem("nvi", 'Command.Knit\ and\ PDF\ (cur\ file)', '<Plug>RMakePDFK', 'kp', ':call RMakePDFrrst()')


### PR DESCRIPTION
rmarkdown essentially is a wrapper for knitr and pandoc.

This is related to jalvesaq/VimCom#10

I think I've switched all the all the rmd knit-ing to the rmarkdown package without losing any of the previous functionality.  In addition to the output types that were already supported, other types can be specified in the .Rmd file yaml header. 

I combined all the RMake*rmd functions into one, since this is quite easy with rmarkdown and should lead to a cleaner codebase for the vim-r-plugin.  I also added two new mappings: RMakeRmd which makes the default type (first specified in yaml, or if nothing specified, html) and RMakeAll which makes all the types specified in the yaml.  I am pretty sure that a person previously using rmd with the vim-r-plugin will not notice any change in functionality except that they will need to install the rmarkdown package: http://rmarkdown.rstudio.com/.

Finally, I think that the vim.interlace.rmd() function in VimCom is no longer needed.
