### PR TITLE
let g:vimrplugin_assign = 2 swaps precedence of '_' and '<-'

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -93,7 +93,7 @@ function ReplaceUnderS()
                 let isString = 1
                 if s[j-1] == '"' || s[j-1] == "'" && g:vimrplugin_assign == 1
                     let synName = synIDattr(synID(line("."), j-2, 1), "name")
-                    if (synName == "rString" || synName == "rSpecial")
+                    if synName == "rString" || synName == "rSpecial"
                         let isString = 0
                     endif
                 endif


### PR DESCRIPTION
This modification allows the swapping of precedence between '_' and '<-' when g:vimrplugin_assign == 2.

The behavior is as follows:
- Insertion of '_' after a '_' changes it to ' <- '
- Insertion of '_' after a ' <- ' replaces it with '__'
  Else:
- Insertion of '_' leaves '_'

Thanks!

Harold
