### PR TITLE
bugfix for when inserting <- in the middle of line

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -107,7 +107,14 @@ function ReplaceUnderS()
                         let @@ = save_unnamed_reg
                         return
                     else
-                        exe "normal! 1x"
+                        if s[j+1] == $
+                            exe "normal! 1x"
+                        else
+                            let save_unnamed_reg = @@
+                            exe "normal! 1xi <- "
+                            let @@ = save_unnamed_reg
+                            return
+                        endif
                     endif
                 endif
             endif


### PR DESCRIPTION
When g:vimrplugin_assign = 2

Old behavior:

Test line:
123456

Inserting ' <- ' between 3 & 4 results in:
1234 <- 56

New behavior: Inserting between 3 & 4 results in:
123 <- 456

as expected
