### PR TITLE
Unreplace of assign_map should be to g:vimrplugin_assign_map

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -120,7 +120,7 @@ function ReplaceUnderS()
         endif
     endif
     if isString
-        exe "normal! a_"
+        exe "normal! a" . g:vimrplugin_assign_map
     else
         exe "normal! a <- "
     endif


### PR DESCRIPTION
Behavior was not correct in the case that vimrplugin_assign_map is set
to something other than "(underscore)".  "Un"replacing vimrplugin_assign_map was
using "(underscore)" instead of the vimrplugin_assign_map string.

(underscore is written out because of markdown)
