### PR TITLE
Check if map exists before trying to unmap it.

### DIFF
--- a/ftplugin/rbrowser.vim
+++ b/ftplugin/rbrowser.vim
@@ -347,7 +347,7 @@ if g:rplugin_do_tmux_split == 0
 else
     au BufUnload <buffer> call ObBrBufUnload()
     " Fix problems caused by some plugins
-    if exists("g:loaded_surround")
+    if exists("g:loaded_surround") && mapcheck("ds", "n") != ""
         nunmap ds
     endif
     if exists("g:loaded_showmarks ")


### PR DESCRIPTION
If ds is not mapped even though vim-surround is loaded (perhaps one has
custom mappings), then when the rbrowser is started an annoying error
pops up.  Check if ds mapping exists before trying to unmap it.
