### PR TITLE
Make more mappings respect vimrplugin_user_maps_only

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -472,8 +472,8 @@ Edit
   . Uncomment (line, sel)                              \xu
   . Add/Align right comment (line, sel)                 \;
   --------------------------------------------------------
-  . Go (next R chunk)                                   gn
-  . Go (previous R chunk)                               gN
+  . Go (next R chunk)                                  \gn
+  . Go (previous R chunk)                              \gN
 -----------------------------------------------------------
 
 Object Browser
@@ -2204,6 +2204,8 @@ RD, "cursor down"; RED, both "echo" and "down"):
    RSyncFor   (SyncTeX search forward)
    RGoToTeX   (Got to LaTeX output)
    RSpinFile
+   RNextRChunk
+   RPreviousRChunk
 
    Object browser~
    RUpdateObjBrowser

--- a/ftplugin/rmd_rplugin.vim
+++ b/ftplugin/rmd_rplugin.vim
@@ -130,19 +130,19 @@ call RControlMaps()
 call RCreateMaps("nvi", '<Plug>RSetwd',        'rd', ':call RSetWD()')
 
 " Only .Rmd files use these functions:
-call RCreateMaps("nvi", '<Plug>RKnit',        'kn', ':call RKnit()')
-call RCreateMaps("nvi", '<Plug>RMakeRmd',     'kr', ':call RMakeRmd("default")')
-call RCreateMaps("nvi", '<Plug>RMakeAll',     'ka', ':call RMakeRmd("all")')
-call RCreateMaps("nvi", '<Plug>RMakePDFK',    'kp', ':call RMakeRmd("pdf_document")')
-call RCreateMaps("nvi", '<Plug>RMakePDFKb',   'kl', ':call RMakeRmd("beamer_presentation")')
-call RCreateMaps("nvi", '<Plug>RMakeHTML',    'kh', ':call RMakeRmd("html_document")')
-call RCreateMaps("nvi", '<Plug>RMakeODT',     'ko', ':call RMakeRmd("odt")')
-call RCreateMaps("ni",  '<Plug>RSendChunk',   'cc', ':call b:SendChunkToR("silent", "stay")')
-call RCreateMaps("ni",  '<Plug>RESendChunk',  'ce', ':call b:SendChunkToR("echo", "stay")')
-call RCreateMaps("ni",  '<Plug>RDSendChunk',  'cd', ':call b:SendChunkToR("silent", "down")')
-call RCreateMaps("ni",  '<Plug>REDSendChunk', 'ca', ':call b:SendChunkToR("echo", "down")')
-nmap <buffer><silent> gn :call b:NextRChunk()<CR>
-nmap <buffer><silent> gN :call b:PreviousRChunk()<CR>
+call RCreateMaps("nvi", '<Plug>RKnit',          'kn', ':call RKnit()')
+call RCreateMaps("nvi", '<Plug>RMakeRmd',       'kr', ':call RMakeRmd("default")')
+call RCreateMaps("nvi", '<Plug>RMakeAll',       'ka', ':call RMakeRmd("all")')
+call RCreateMaps("nvi", '<Plug>RMakePDFK',      'kp', ':call RMakeRmd("pdf_document")')
+call RCreateMaps("nvi", '<Plug>RMakePDFKb',     'kl', ':call RMakeRmd("beamer_presentation")')
+call RCreateMaps("nvi", '<Plug>RMakeHTML',      'kh', ':call RMakeRmd("html_document")')
+call RCreateMaps("nvi", '<Plug>RMakeODT',       'ko', ':call RMakeRmd("odt")')
+call RCreateMaps("ni",  '<Plug>RSendChunk',     'cc', ':call b:SendChunkToR("silent", "stay")')
+call RCreateMaps("ni",  '<Plug>RESendChunk',    'ce', ':call b:SendChunkToR("echo", "stay")')
+call RCreateMaps("ni",  '<Plug>RDSendChunk',    'cd', ':call b:SendChunkToR("silent", "down")')
+call RCreateMaps("ni",  '<Plug>REDSendChunk',   'ca', ':call b:SendChunkToR("echo", "down")')
+call RCreateMaps("n",  '<Plug>RNextRChunk',     'gn', ':call b:NextRChunk()')
+call RCreateMaps("n",  '<Plug>RPreviousRChunk', 'gN', ':call b:PreviousRChunk()')
 
 " Menu R
 if has("gui_running")

--- a/ftplugin/rnoweb_rplugin.vim
+++ b/ftplugin/rnoweb_rplugin.vim
@@ -273,8 +273,8 @@ if g:vimrplugin_synctex
     call RCreateMaps("ni",  '<Plug>RSyncFor',     'gp', ':call SyncTeX_forward()')
     call RCreateMaps("ni",  '<Plug>RGoToTeX',     'gt', ':call SyncTeX_forward(1)')
 endif
-nmap <buffer><silent> gn :call RnwNextChunk()<CR>
-nmap <buffer><silent> gN :call RnwPreviousChunk()<CR>
+call RCreateMaps("n",  '<Plug>RNextRChunk',     'gn', ':call b:NextRChunk()')
+call RCreateMaps("n",  '<Plug>RPreviousRChunk', 'gN', ':call b:PreviousRChunk()')
 
 " Menu R
 if has("gui_running")

--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -2274,7 +2274,7 @@ function RSendPartOfLine(direction, correctpos)
     if a:direction == "right"
         let rcmd = strpart(lin, idx)
     else
-        let rcmd = strpart(lin, 0, idx)
+        let rcmd = strpart(lin, 0, idx + 1)
     endif
     call g:SendCmdToR(rcmd)
 endfunction
@@ -3647,12 +3647,10 @@ function RCreateSendMaps()
     call RCreateMaps('ni0', '<Plug>RDSendLine', 'd', ':call SendLineToR("down")')
     call RCreateMaps('ni0', '<Plug>RDSendLineAndInsertOutput', 'o', ':call SendLineToRAndInsertOutput()')
     call RCreateMaps('i', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
-    nmap <LocalLeader>r<Left> :call RSendPartOfLine("left", 0)<CR>
-    nmap <LocalLeader>r<Right> :call RSendPartOfLine("right", 0)<CR>
-    if g:vimrplugin_insert_mode_cmds
-        imap <buffer><silent> <LocalLeader>r<Left> <Esc>l:call RSendPartOfLine("left", 0)<CR>i
-        imap <buffer><silent> <LocalLeader>r<Right> <Esc>l:call RSendPartOfLine("right", 0)<CR>i
-    endif
+    call RCreateMaps('n', '<Plug>RNLeftPart', 'r<left>', ':call RSendPartOfLine("left", 0)')
+    call RCreateMaps('n', '<Plug>RNRightPart', 'r<right>', ':call RSendPartOfLine("right", 0)')
+    call RCreateMaps('i', '<Plug>RILeftPart', 'r<left>', 'l:call RSendPartOfLine("left", 1)')
+    call RCreateMaps('i', '<Plug>RIRightPart', 'r<right>', 'l:call RSendPartOfLine("right", 1)')
 
     " For compatibility with Johannes Ranke's plugin
     if g:vimrplugin_map_r == 1


### PR DESCRIPTION
There were two that I noticed:

RSendPartOfLine:

Some infrastructure was already set up for this (RNRightPart,
RIRightPart, RNLeftPart, RILeftPart) were already mentioned in the doc
but not really set up.  I also changed the function a little.  Sending
right would send the right part including the cursor and sending left
would send the left part without the cursor.  Now they both send the
cursor.

RNextRChunk/RPreviousChunk:

These were stealing gn and gN which are actually built-in vim commands.
The RCreateMaps puts LocalLeader in front of the maps so these are now
\gn and \gN.  I considered adding another flag in a:type to not include
LocalLeader in the maps, but I decided to keep it simple.  Instead I
was going to make a note in the doc about the change of these maps
(addition of LocalLeader) and how to map without the LocalLeader (just
put the original code into ftplugin/rmd.vim), but I wasn't sure where a
good place for this would be in the doc.
