### PR TITLE
Hint to use the Shift key for copying from tmux

### DIFF
--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -870,10 +870,11 @@ pane and, then, paste.
 
 However, if you want to copy something from either Vim or R to another
 application not running inside Tmux, Tmux may prevent the X server from
-capturing the text selected by the mouse. The solution is to press
-the <Shift> key while selecting text with the mouse, so the selected
-text is transferred to the X server clipboard and can be inserted using
-the middle mouse button.
+capturing the text selected by the mouse. This can be prevented by
+pressing the <Shift> key, as it suspends the capturing of mouse events
+by tmux. If you keep <Shift> pressed while selecting text with the mouse, 
+it will be available in the X server clipboard and can be inserted
+using the middle mouse button.
 
 ------------------------------------------------------------------------------
 							     *r-plugin-remote*

--- a/doc/r-plugin.txt
+++ b/doc/r-plugin.txt
@@ -870,12 +870,10 @@ pane and, then, paste.
 
 However, if you want to copy something from either Vim or R to another
 application not running inside Tmux, Tmux may prevent the X server from
-capturing the text selected by the mouse. The solution is to disable mouse
-support in Tmux. You will be able to toggle mouse support on and off by typing
-<C-a>m if you add the following line to your ~/.tmux.conf:
->
-   bind m run-shell '( if [ "mode-mouse off" = "$(tmux show-window-option mode-mouse)" ]; then toggle=on; else toggle=off; fi; tmux display-message "mouse $toggle"; tmux set-option -w mode-mouse $toggle ; for cmd in mouse-select-pane mouse-resize-pane mouse-select-window; do tmux set-option -g $cmd $toggle ; done;) > /dev/null 2>&1'
-<
+capturing the text selected by the mouse. The solution is to press
+the <Shift> key while selecting text with the mouse, so the selected
+text is transferred to the X server clipboard and can be inserted using
+the middle mouse button.
 
 ------------------------------------------------------------------------------
 							     *r-plugin-remote*


### PR DESCRIPTION
Hello Jakson,

Thanks for all your excellent work on the Vim-R-plugin! I am using it for all my work with R under Linux and Windows.

As I usually have the R console in a separate terminal application under tmux when I am on Linux, I often want to copy output from R somewhere else.

The solution with toggling mouse support did not work for me, but
when I press the Shift key, the mouse selection ends up in the X
clipboard.

Cheers,

Johannes